### PR TITLE
feat(samples): add community-contributed samples for clone with static IP, datastore clusters, and file transfer

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/samples/storage/DatastoreFileTransfer.java
+++ b/src/main/java/com/vmware/vim25/mo/samples/storage/DatastoreFileTransfer.java
@@ -1,0 +1,252 @@
+/*================================================================================
+Copyright (c) 2008 VMware, Inc. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+ * Neither the name of VMware, Inc. nor the names of its contributors may be used
+to endorse or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+================================================================================*/
+
+package com.vmware.vim25.mo.samples.storage;
+
+import com.vmware.vim25.DatastoreHostMount;
+import com.vmware.vim25.SessionManagerGenericServiceTicket;
+import com.vmware.vim25.SessionManagerHttpServiceRequestSpec;
+import com.vmware.vim25.mo.Datastore;
+import com.vmware.vim25.mo.Folder;
+import com.vmware.vim25.mo.HostSystem;
+import com.vmware.vim25.mo.InventoryNavigator;
+import com.vmware.vim25.mo.ManagedObject;
+import com.vmware.vim25.mo.ServiceInstance;
+import com.vmware.vim25.mo.samples.HttpsConnectionUtil;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+
+/**
+ * Demonstrates uploading a local file to a vSphere datastore and downloading
+ * a file from a datastore using the vSphere HTTP datastore access API with a
+ * generic service ticket for authentication (no SOAP session cookie required).
+ *
+ * Usage:
+ *   java DatastoreFileTransfer &lt;url&gt; &lt;username&gt; &lt;password&gt;
+ *       &lt;datacenter-name&gt; &lt;datastore-name&gt; &lt;local-file&gt;
+ *       &lt;remote-path&gt; &lt;upload|download&gt;
+ *
+ * Example (upload):
+ *   java DatastoreFileTransfer https://vc01/sdk administrator@vsphere.local vmware123
+ *       DC0 datastore1 /tmp/hello.txt hello/hello.txt upload
+ *
+ * Example (download):
+ *   java DatastoreFileTransfer https://vc01/sdk administrator@vsphere.local vmware123
+ *       DC0 datastore1 /tmp/hello.txt hello/hello.txt download
+ *
+ * The remote-path is relative to the datastore root, e.g. "folder/file.txt".
+ *
+ * Background: GitHub issue #239 — community-contributed pattern using
+ * SessionManager.acquireGenericServiceTicket() with a vmware_client_session_id
+ * cookie header instead of the SOAP session cookie, enabling stateless HTTP
+ * access to the datastore browser endpoint.
+ *
+ * http://vijava.sf.net
+ * @author yavijava contributors
+ */
+public class DatastoreFileTransfer {
+
+    private static final int BUFFER_SIZE = 64 * 1024; // 64 KB
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 8) {
+            System.out.println("Usage: java DatastoreFileTransfer <url> <username> <password>"
+                    + " <datacenter-name> <datastore-name> <local-file> <remote-path>"
+                    + " <upload|download>");
+            System.out.println();
+            System.out.println("  url            vCenter SDK endpoint, e.g. https://vc01/sdk");
+            System.out.println("  datacenter-name  name of the datacenter that owns the datastore");
+            System.out.println("  datastore-name   name of the target datastore");
+            System.out.println("  local-file       absolute path to the local file");
+            System.out.println("  remote-path      path relative to datastore root, e.g. folder/file.txt");
+            System.out.println("  upload|download  direction of transfer");
+            System.exit(0);
+        }
+
+        String vcUrl       = args[0];
+        String username    = args[1];
+        String password    = args[2];
+        String dcName      = args[3];
+        String dsName      = args[4];
+        String localFile   = args[5];
+        String remotePath  = args[6];
+        String direction   = args[7].toLowerCase();
+
+        if (!direction.equals("upload") && !direction.equals("download")) {
+            System.out.println("Error: last argument must be 'upload' or 'download'");
+            System.exit(1);
+        }
+
+        // 1. Connect to vCenter.
+        ServiceInstance si = new ServiceInstance(new URL(vcUrl), username, password, true);
+        System.out.println("Connected to vCenter: " + vcUrl);
+
+        try {
+            Folder rootFolder = si.getRootFolder();
+
+            // 2. Find the target Datastore by name.
+            Datastore datastore = (Datastore) new InventoryNavigator(rootFolder)
+                    .searchManagedEntity("Datastore", dsName);
+            if (datastore == null) {
+                System.out.println("Error: datastore '" + dsName + "' not found.");
+                return;
+            }
+            System.out.println("Found datastore: " + dsName);
+
+            // 3. Get the IP of a host that mounts this datastore.
+            DatastoreHostMount[] mounts = datastore.getHost();
+            if (mounts == null || mounts.length == 0) {
+                System.out.println("Error: no hosts found for datastore '" + dsName + "'.");
+                return;
+            }
+
+            // Resolve the host MOR to a HostSystem and retrieve its management IP.
+            HostSystem host = new HostSystem(
+                    si.getServerConnection(), mounts[0].getKey());
+            String hostIp = host.getSummary().managementServerIp;
+            if (hostIp == null || hostIp.isEmpty()) {
+                // Fall back to the host's display name if no management IP is set.
+                hostIp = host.getName();
+            }
+            System.out.println("Using host: " + hostIp);
+
+            // 4. Build the datastore browser URL.
+            //    Pattern: https://<host-ip>/folder/<remote-path>?dcPath=<dc-name>&dsName=<ds-name>
+            String datastoreUrl = "https://" + hostIp + "/folder/"
+                    + remotePath.replaceAll(" ", "%20")
+                    + "?dcPath=" + dcName.replaceAll(" ", "%20")
+                    + "&dsName=" + dsName.replaceAll(" ", "%20");
+            System.out.println("Datastore URL: " + datastoreUrl);
+
+            // 5. Acquire a generic service ticket for this URL.
+            //    The ticket is single-use and grants access without a SOAP session cookie.
+            SessionManagerHttpServiceRequestSpec ticketSpec =
+                    new SessionManagerHttpServiceRequestSpec();
+            ticketSpec.setUrl(datastoreUrl);
+            ticketSpec.setMethod(direction.equals("upload") ? "httpPut" : "httpGet");
+
+            SessionManagerGenericServiceTicket ticket =
+                    si.getSessionManager().acquireGenericServiceTicket(ticketSpec);
+            System.out.println("Acquired service ticket: " + ticket.getId());
+
+            // 6. Open an HttpsURLConnection, trusting all certificates (development convenience).
+            //    In production, configure a proper TrustManager with the host's certificate.
+            HttpsConnectionUtil.trustAllHosts();
+            URL url = new URL(datastoreUrl);
+            HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+            conn.setHostnameVerifier(HttpsConnectionUtil.DO_NOT_VERIFY);
+
+            // Attach the service ticket as a cookie header.
+            conn.setRequestProperty("Cookie", "vmware_client_session_id=" + ticket.getId());
+
+            if (direction.equals("upload")) {
+                uploadFile(conn, localFile);
+            } else {
+                downloadFile(conn, localFile);
+            }
+
+            conn.disconnect();
+            System.out.println("Transfer complete.");
+
+        } finally {
+            si.getServerConnection().logout();
+        }
+    }
+
+    /**
+     * Uploads localFilePath to the datastore via HTTP PUT.
+     */
+    private static void uploadFile(HttpsURLConnection conn, String localFilePath) throws Exception {
+        File file = new File(localFilePath);
+        if (!file.exists()) {
+            throw new IllegalArgumentException("Local file not found: " + localFilePath);
+        }
+
+        conn.setDoOutput(true);
+        conn.setDoInput(true);
+        conn.setRequestMethod("PUT");
+        conn.setRequestProperty("Content-Type", "application/octet-stream");
+        conn.setChunkedStreamingMode(BUFFER_SIZE);
+
+        System.out.println("Uploading '" + localFilePath + "' (" + file.length() + " bytes) ...");
+
+        try (InputStream in = new BufferedInputStream(new FileInputStream(file));
+             OutputStream out = conn.getOutputStream()) {
+            byte[] buf = new byte[BUFFER_SIZE];
+            int len;
+            while ((len = in.read(buf)) != -1) {
+                out.write(buf, 0, len);
+            }
+            out.flush();
+        }
+
+        int responseCode = conn.getResponseCode();
+        System.out.println("Server response: " + responseCode + " " + conn.getResponseMessage());
+        if (responseCode < 200 || responseCode >= 300) {
+            throw new RuntimeException("Upload failed with HTTP " + responseCode);
+        }
+    }
+
+    /**
+     * Downloads a file from the datastore via HTTP GET and saves it to localFilePath.
+     */
+    private static void downloadFile(HttpsURLConnection conn, String localFilePath) throws Exception {
+        conn.setDoInput(true);
+        conn.setRequestMethod("GET");
+
+        System.out.println("Downloading to '" + localFilePath + "' ...");
+
+        int responseCode = conn.getResponseCode();
+        if (responseCode < 200 || responseCode >= 300) {
+            throw new RuntimeException("Download failed with HTTP " + responseCode
+                    + " " + conn.getResponseMessage());
+        }
+
+        try (InputStream in = new BufferedInputStream(conn.getInputStream());
+             OutputStream out = new BufferedOutputStream(new FileOutputStream(localFilePath))) {
+            byte[] buf = new byte[BUFFER_SIZE];
+            long totalBytes = 0;
+            int len;
+            while ((len = in.read(buf)) != -1) {
+                out.write(buf, 0, len);
+                totalBytes += len;
+            }
+            out.flush();
+            System.out.println("Downloaded " + totalBytes + " bytes.");
+        }
+    }
+}

--- a/src/main/java/com/vmware/vim25/mo/samples/storage/ListDatastoreClusters.java
+++ b/src/main/java/com/vmware/vim25/mo/samples/storage/ListDatastoreClusters.java
@@ -1,0 +1,97 @@
+/*================================================================================
+Copyright (c) 2008 VMware, Inc. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+ * Neither the name of VMware, Inc. nor the names of its contributors may be used
+to endorse or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+================================================================================*/
+
+package com.vmware.vim25.mo.samples.storage;
+
+import java.net.URL;
+
+import com.vmware.vim25.mo.Datastore;
+import com.vmware.vim25.mo.InventoryNavigator;
+import com.vmware.vim25.mo.ManagedEntity;
+import com.vmware.vim25.mo.ServiceInstance;
+import com.vmware.vim25.mo.StoragePod;
+
+/**
+ * Connects to a vCenter server and lists all Datastore Clusters (StoragePods)
+ * along with the Datastores contained within each cluster.
+ *
+ * Usage: java ListDatastoreClusters &lt;url&gt; &lt;username&gt; &lt;password&gt;
+ *
+ * Based on community code from GitHub issue #246.
+ *
+ * http://vijava.sf.net
+ * @author Steve Jin
+ */
+
+public class ListDatastoreClusters
+{
+  public static void main(String[] args) throws Exception
+  {
+    if (args.length != 3)
+    {
+      System.out.println("Usage: java ListDatastoreClusters <url> <username> <password>");
+      System.exit(0);
+    }
+
+    ServiceInstance si = new ServiceInstance(
+        new URL(args[0]), args[1], args[2], true);
+
+    ManagedEntity[] storagePods = new InventoryNavigator(
+        si.getRootFolder()).searchManagedEntities(
+            new String[][] { {"StoragePod", "name"} }, true);
+
+    if (storagePods == null || storagePods.length == 0)
+    {
+      System.out.println("No Datastore Clusters found.");
+    }
+    else
+    {
+      for (ManagedEntity entity : storagePods)
+      {
+        StoragePod storagePod = (StoragePod) entity;
+        System.out.println("Datastore Cluster: " + storagePod.getName());
+
+        ManagedEntity[] children = storagePod.getChildEntity();
+        if (children != null)
+        {
+          for (ManagedEntity child : children)
+          {
+            if (child instanceof Datastore)
+            {
+              Datastore datastore = (Datastore) child;
+              System.out.println("  --> Datastore: " + datastore.getName());
+            }
+          }
+        }
+      }
+    }
+
+    si.getServerConnection().logout();
+  }
+}

--- a/src/main/java/com/vmware/vim25/mo/samples/vm/CloneVMWithStaticIP.java
+++ b/src/main/java/com/vmware/vim25/mo/samples/vm/CloneVMWithStaticIP.java
@@ -1,0 +1,159 @@
+/*================================================================================
+Copyright (c) 2008 VMware, Inc. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+ * Neither the name of VMware, Inc. nor the names of its contributors may be used
+to endorse or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+================================================================================*/
+
+package com.vmware.vim25.mo.samples.vm;
+
+import java.net.URL;
+
+import com.vmware.vim25.CustomizationAdapterMapping;
+import com.vmware.vim25.CustomizationFixedIp;
+import com.vmware.vim25.CustomizationGlobalIPSettings;
+import com.vmware.vim25.CustomizationIPSettings;
+import com.vmware.vim25.CustomizationSpec;
+import com.vmware.vim25.CustomizationSpecItem;
+import com.vmware.vim25.VirtualMachineCloneSpec;
+import com.vmware.vim25.VirtualMachineRelocateSpec;
+import com.vmware.vim25.mo.CustomizationSpecManager;
+import com.vmware.vim25.mo.Folder;
+import com.vmware.vim25.mo.InventoryNavigator;
+import com.vmware.vim25.mo.ServiceInstance;
+import com.vmware.vim25.mo.Task;
+import com.vmware.vim25.mo.VirtualMachine;
+
+/**
+ * Clones a VM from a template and applies a static IP address using a vCenter
+ * OS Customization Spec as the base for identity/OS settings, then overrides
+ * the NIC mapping with user-supplied static IP configuration.
+ *
+ * Based on community code from yavijava GitHub issue #248.
+ *
+ * Usage:
+ *   java CloneVMWithStaticIP <url> <username> <password> <template-name>
+ *       <clone-name> <customization-spec-name> <ip> <gateway> <subnet> <dns>
+ *
+ * http://vijava.sf.net
+ */
+public class CloneVMWithStaticIP
+{
+  public static void main(String[] args) throws Exception
+  {
+    if (args.length != 10)
+    {
+      System.out.println("Usage: java CloneVMWithStaticIP <url> <username> <password>" +
+          " <template-name> <clone-name> <customization-spec-name>" +
+          " <ip> <gateway> <subnet> <dns>");
+      System.exit(0);
+    }
+
+    String url              = args[0];
+    String username         = args[1];
+    String password         = args[2];
+    String templateName     = args[3];
+    String cloneName        = args[4];
+    String specName         = args[5];
+    String ipAddress        = args[6];
+    String gateway          = args[7];
+    String netmask          = args[8];
+    String dnsServer        = args[9];
+
+    ServiceInstance si = new ServiceInstance(new URL(url), username, password, true);
+
+    Folder rootFolder = si.getRootFolder();
+
+    VirtualMachine template = (VirtualMachine) new InventoryNavigator(
+        rootFolder).searchManagedEntity("VirtualMachine", templateName);
+
+    if (template == null)
+    {
+      System.out.println("No VM/template named '" + templateName + "' found.");
+      si.getServerConnection().logout();
+      return;
+    }
+
+    // Load the named OS Customization Spec from vCenter to get identity/OS settings.
+    CustomizationSpecManager csManager = si.getCustomizationSpecManager();
+    CustomizationSpecItem cSpecItem = csManager.getCustomizationSpec(specName);
+
+    if (cSpecItem == null)
+    {
+      System.out.println("No customization spec named '" + specName + "' found.");
+      si.getServerConnection().logout();
+      return;
+    }
+
+    // Build the customization spec, borrowing identity and options from the
+    // named spec, then overriding the NIC mapping with static IP settings.
+    CustomizationSpec vmCustomizationSpec = new CustomizationSpec();
+    vmCustomizationSpec.setOptions(cSpecItem.getSpec().getOptions());
+    vmCustomizationSpec.setIdentity(cSpecItem.getSpec().getIdentity());
+
+    // Global IP settings (DNS servers and suffix list).
+    CustomizationGlobalIPSettings vmIpSettings = new CustomizationGlobalIPSettings();
+    vmIpSettings.setDnsServerList(new String[] { dnsServer });
+    vmIpSettings.setDnsSuffixList(new String[] { "local" });
+
+    // Fixed (static) IP for the first NIC.
+    CustomizationFixedIp vmFixedIp = new CustomizationFixedIp();
+    vmFixedIp.setIpAddress(ipAddress);
+
+    CustomizationIPSettings vmAdapter = new CustomizationIPSettings();
+    vmAdapter.setIp(vmFixedIp);
+    vmAdapter.setGateway(new String[] { gateway });
+    vmAdapter.setSubnetMask(netmask);
+
+    CustomizationAdapterMapping adapterMap = new CustomizationAdapterMapping();
+    adapterMap.setAdapter(vmAdapter);
+
+    vmCustomizationSpec.setGlobalIPSettings(vmIpSettings);
+    vmCustomizationSpec.setNicSettingMap(new CustomizationAdapterMapping[] { adapterMap });
+
+    // Build the clone spec.
+    VirtualMachineCloneSpec cloneSpec = new VirtualMachineCloneSpec();
+    cloneSpec.setLocation(new VirtualMachineRelocateSpec());
+    cloneSpec.setPowerOn(false);
+    cloneSpec.setTemplate(false);
+    cloneSpec.setCustomization(vmCustomizationSpec);
+
+    System.out.println("Launching the VM clone task. Please wait ...");
+
+    Task task = template.cloneVM_Task((Folder) template.getParent(), cloneName, cloneSpec);
+
+    String status = task.waitForMe();
+    if (status == Task.SUCCESS)
+    {
+      System.out.println("VM cloned successfully as '" + cloneName + "' with static IP " + ipAddress + ".");
+    }
+    else
+    {
+      System.out.println("Failure: VM could not be cloned.");
+    }
+
+    si.getServerConnection().logout();
+  }
+}


### PR DESCRIPTION
## Summary

Three new samples converting community-contributed code from GitHub issues into proper runnable examples:

- **`vm/CloneVMWithStaticIP.java`** — clones a VM from template applying a static IP, using a named vCenter OS Customization Spec for identity/OS settings and overriding the NIC mapping (addresses yavijava/yavijava#248)
- **`storage/ListDatastoreClusters.java`** — lists all Datastore Clusters (StoragePods) and the Datastores contained in each (addresses yavijava/yavijava#246)
- **`storage/DatastoreFileTransfer.java`** — uploads or downloads files to/from a datastore via the vSphere HTTP browser API, using `SessionManager.acquireGenericServiceTicket()` for authentication (addresses yavijava/yavijava#239)

## Test plan

- [ ] `CloneVMWithStaticIP` — run against a test vCenter with a known template and customization spec, verify VM clones with correct static IP
- [ ] `ListDatastoreClusters` — run against a vCenter with at least one StoragePod, verify output lists clusters and member datastores
- [ ] `DatastoreFileTransfer upload` — upload a test file and verify it appears in the datastore browser
- [ ] `DatastoreFileTransfer download` — download a known file and verify contents match

🤖 Generated with [Claude Code](https://claude.com/claude-code)