### PR TITLE
samples(guestos): three Guest Operations helpers (yavijava#49)

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/samples/guestos/DownloadFileFromGuest.java
+++ b/src/main/java/com/vmware/vim25/mo/samples/guestos/DownloadFileFromGuest.java
@@ -1,0 +1,123 @@
+package com.vmware.vim25.mo.samples.guestos;
+
+import com.vmware.vim25.FileTransferInformation;
+import com.vmware.vim25.NamePasswordAuthentication;
+import com.vmware.vim25.mo.GuestFileManager;
+import com.vmware.vim25.mo.GuestOperationsManager;
+import com.vmware.vim25.mo.HostSystem;
+import com.vmware.vim25.mo.InventoryNavigator;
+import com.vmware.vim25.mo.ServiceInstance;
+import com.vmware.vim25.mo.VirtualMachine;
+import com.vmware.vim25.mo.samples.HttpsConnectionUtil;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+
+/**
+ * Downloads a file from a powered-on VM's guest OS to local disk using the
+ * GuestFileManager.initiateFileTransferFromGuest API.
+ *
+ * <p>Pattern (mirrors what the doublecloud vmguest "getFile" helper did, GitHub issue #49):
+ * <ol>
+ *   <li>Authenticate to vCenter and locate the target VM.</li>
+ *   <li>Authenticate to the guest OS via VMware Tools using NamePasswordAuthentication.</li>
+ *   <li>Call initiateFileTransferFromGuest to get a {@link FileTransferInformation} with a
+ *       single-use download URL (with "*" placeholder for the VM's host) and the size in bytes.</li>
+ *   <li>Substitute the actual ESXi host IP/hostname into the URL.</li>
+ *   <li>HTTP GET the bytes and stream them to a local file.</li>
+ * </ol>
+ *
+ * <p>Requires VMware Tools running in the guest. The guest user must have permission to
+ * read the source path.
+ *
+ * <p>Usage:
+ * <pre>
+ * java DownloadFileFromGuest &lt;url&gt; &lt;vc-user&gt; &lt;vc-pass&gt; &lt;vm-name&gt;
+ *     &lt;guest-user&gt; &lt;guest-pass&gt; &lt;guest-path&gt; &lt;local-file&gt;
+ *
+ * java DownloadFileFromGuest https://vc01/sdk administrator@vsphere.local vmware123
+ *     test-vm root rootpw /var/log/messages /tmp/messages
+ * </pre>
+ */
+public class DownloadFileFromGuest {
+
+    private static final int BUFFER_SIZE = 64 * 1024;
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 8) {
+            System.out.println("Usage: java DownloadFileFromGuest <url> <vc-user> <vc-pass> <vm-name>"
+                + " <guest-user> <guest-pass> <guest-path> <local-file>");
+            System.exit(0);
+        }
+
+        String vcUrl     = args[0];
+        String vcUser    = args[1];
+        String vcPass    = args[2];
+        String vmName    = args[3];
+        String guestUser = args[4];
+        String guestPass = args[5];
+        String guestPath = args[6];
+        String localFile = args[7];
+
+        ServiceInstance si = new ServiceInstance(new URL(vcUrl), vcUser, vcPass, true);
+        try {
+            VirtualMachine vm = (VirtualMachine) new InventoryNavigator(si.getRootFolder())
+                .searchManagedEntity("VirtualMachine", vmName);
+            if (vm == null) {
+                System.out.println("VM not found: " + vmName);
+                return;
+            }
+            if (!"guestToolsRunning".equals(vm.getGuest().toolsRunningStatus)) {
+                System.out.println("VMware Tools not running in guest; cannot proceed.");
+                return;
+            }
+
+            NamePasswordAuthentication creds = new NamePasswordAuthentication();
+            creds.username = guestUser;
+            creds.password = guestPass;
+
+            GuestOperationsManager gom = si.getGuestOperationsManager();
+            GuestFileManager fileManager = gom.getFileManager(vm);
+
+            FileTransferInformation info = fileManager.initiateFileTransferFromGuest(
+                vm, creds, guestPath);
+
+            String hostUrl = UploadFileToGuest.substituteHost(info.getUrl(), vm);
+            System.out.println("Download URL: " + hostUrl);
+            System.out.println("Reported size: " + info.getSize() + " bytes");
+
+            HttpsConnectionUtil.trustAllHosts();
+            URL url = new URL(hostUrl);
+            HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+            conn.setHostnameVerifier(HttpsConnectionUtil.DO_NOT_VERIFY);
+            conn.setRequestMethod("GET");
+
+            int rc = conn.getResponseCode();
+            if (rc < 200 || rc >= 300) {
+                throw new RuntimeException("Download failed with HTTP " + rc
+                    + " " + conn.getResponseMessage());
+            }
+
+            long total = 0;
+            try (InputStream in = new BufferedInputStream(conn.getInputStream());
+                 OutputStream out = new BufferedOutputStream(new FileOutputStream(localFile))) {
+                byte[] buf = new byte[BUFFER_SIZE];
+                int len;
+                while ((len = in.read(buf)) != -1) {
+                    out.write(buf, 0, len);
+                    total += len;
+                }
+                out.flush();
+            }
+            System.out.println("Downloaded " + total + " bytes to " + localFile);
+            conn.disconnect();
+        } finally {
+            si.getServerConnection().logout();
+        }
+    }
+}

--- a/src/main/java/com/vmware/vim25/mo/samples/guestos/RunCommandInGuestAndCaptureOutput.java
+++ b/src/main/java/com/vmware/vim25/mo/samples/guestos/RunCommandInGuestAndCaptureOutput.java
@@ -1,0 +1,177 @@
+package com.vmware.vim25.mo.samples.guestos;
+
+import com.vmware.vim25.FileTransferInformation;
+import com.vmware.vim25.GuestProcessInfo;
+import com.vmware.vim25.GuestProgramSpec;
+import com.vmware.vim25.NamePasswordAuthentication;
+import com.vmware.vim25.mo.GuestFileManager;
+import com.vmware.vim25.mo.GuestOperationsManager;
+import com.vmware.vim25.mo.GuestProcessManager;
+import com.vmware.vim25.mo.InventoryNavigator;
+import com.vmware.vim25.mo.ServiceInstance;
+import com.vmware.vim25.mo.VirtualMachine;
+import com.vmware.vim25.mo.samples.HttpsConnectionUtil;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * Runs a shell command in a powered-on VM's guest OS and prints its captured stdout and
+ * stderr. Demonstrates the workaround for the vSphere Guest Operations API not directly
+ * exposing process output: redirect into temp files inside the guest, wait for the
+ * process to exit, then download the temp files back via initiateFileTransferFromGuest.
+ *
+ * <p>Pattern (mirrors what the doublecloud vmguest "runScript" / "runCommand" helpers did,
+ * GitHub issue #49):
+ * <ol>
+ *   <li>Pick a shell appropriate for the guest family (cmd.exe vs /bin/sh).</li>
+ *   <li>Compose the command so its stdout/stderr are redirected to two temp files in the guest.</li>
+ *   <li>Start the process via GuestProcessManager.startProgramInGuest.</li>
+ *   <li>Poll listProcessesInGuest until the process exits, capturing the exit code.</li>
+ *   <li>Download the two temp files via GuestFileManager.initiateFileTransferFromGuest.</li>
+ *   <li>Delete the temp files via deleteFileInGuest.</li>
+ * </ol>
+ *
+ * <p>Requires VMware Tools running in the guest with a guest user that can run /bin/sh
+ * or cmd.exe and write to /tmp (Linux) or %TEMP% (Windows).
+ *
+ * <p>Usage:
+ * <pre>
+ * java RunCommandInGuestAndCaptureOutput &lt;url&gt; &lt;vc-user&gt; &lt;vc-pass&gt; &lt;vm-name&gt;
+ *     &lt;guest-user&gt; &lt;guest-pass&gt; &lt;command&gt;
+ *
+ * java RunCommandInGuestAndCaptureOutput https://vc01/sdk administrator@vsphere.local vmware123
+ *     test-vm root rootpw "ls -la /var/log"
+ * </pre>
+ */
+public class RunCommandInGuestAndCaptureOutput {
+
+    private static final long POLL_INTERVAL_MS = 1000;
+    private static final long MAX_WAIT_MS = 5 * 60 * 1000; // 5 minutes
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 7) {
+            System.out.println("Usage: java RunCommandInGuestAndCaptureOutput <url> <vc-user> <vc-pass>"
+                + " <vm-name> <guest-user> <guest-pass> <command>");
+            System.exit(0);
+        }
+
+        String vcUrl     = args[0];
+        String vcUser    = args[1];
+        String vcPass    = args[2];
+        String vmName    = args[3];
+        String guestUser = args[4];
+        String guestPass = args[5];
+        String command   = args[6];
+
+        ServiceInstance si = new ServiceInstance(new URL(vcUrl), vcUser, vcPass, true);
+        try {
+            VirtualMachine vm = (VirtualMachine) new InventoryNavigator(si.getRootFolder())
+                .searchManagedEntity("VirtualMachine", vmName);
+            if (vm == null) {
+                System.out.println("VM not found: " + vmName);
+                return;
+            }
+            if (!"guestToolsRunning".equals(vm.getGuest().toolsRunningStatus)) {
+                System.out.println("VMware Tools not running in guest; cannot proceed.");
+                return;
+            }
+
+            String osFamily = vm.getGuest().getGuestFamily();
+            boolean isWindows = osFamily != null && osFamily.contains("windowsGuest");
+            System.out.println("Guest family: " + osFamily);
+
+            NamePasswordAuthentication creds = new NamePasswordAuthentication();
+            creds.username = guestUser;
+            creds.password = guestPass;
+
+            GuestOperationsManager gom = si.getGuestOperationsManager();
+            GuestProcessManager pm = gom.getProcessManager(vm);
+            GuestFileManager fm = gom.getFileManager(vm);
+
+            // Pick guest-appropriate temp file paths and shell wrapping.
+            String runId = "yavijava-" + System.currentTimeMillis();
+            String stdoutPath;
+            String stderrPath;
+            GuestProgramSpec spec = new GuestProgramSpec();
+            if (isWindows) {
+                stdoutPath = "C:\\Windows\\Temp\\" + runId + ".out";
+                stderrPath = "C:\\Windows\\Temp\\" + runId + ".err";
+                spec.programPath = "C:\\Windows\\System32\\cmd.exe";
+                spec.arguments = "/C " + command + " > \"" + stdoutPath + "\" 2> \"" + stderrPath + "\"";
+            } else {
+                stdoutPath = "/tmp/" + runId + ".out";
+                stderrPath = "/tmp/" + runId + ".err";
+                spec.programPath = "/bin/sh";
+                spec.arguments = "-c \"" + command.replace("\"", "\\\"")
+                    + " > " + stdoutPath + " 2> " + stderrPath + "\"";
+            }
+
+            System.out.println("Starting: " + spec.programPath + " " + spec.arguments);
+            long pid = pm.startProgramInGuest(creds, spec);
+            System.out.println("pid: " + pid);
+
+            int exitCode = waitForExit(pm, creds, pid);
+            System.out.println("exit code: " + exitCode);
+
+            String stdout = downloadCapturedFile(fm, vm, creds, stdoutPath);
+            String stderr = downloadCapturedFile(fm, vm, creds, stderrPath);
+
+            System.out.println("---- STDOUT ----");
+            System.out.print(stdout);
+            System.out.println("---- STDERR ----");
+            System.out.print(stderr);
+
+            // Best-effort cleanup; ignore failures (file may already be gone).
+            try { fm.deleteFileInGuest(vm, creds, stdoutPath); } catch (Exception ignored) {}
+            try { fm.deleteFileInGuest(vm, creds, stderrPath); } catch (Exception ignored) {}
+
+        } finally {
+            si.getServerConnection().logout();
+        }
+    }
+
+    private static int waitForExit(GuestProcessManager pm, NamePasswordAuthentication creds, long pid)
+        throws Exception {
+        long deadline = System.currentTimeMillis() + MAX_WAIT_MS;
+        while (System.currentTimeMillis() < deadline) {
+            GuestProcessInfo[] infos = pm.listProcessesInGuest(creds, new long[]{pid});
+            if (infos != null && infos.length > 0 && infos[0].getExitCode() != null) {
+                return infos[0].getExitCode();
+            }
+            Thread.sleep(POLL_INTERVAL_MS);
+        }
+        throw new RuntimeException("Timed out waiting for guest pid " + pid + " to exit");
+    }
+
+    private static String downloadCapturedFile(GuestFileManager fm, VirtualMachine vm,
+                                               NamePasswordAuthentication creds, String guestPath)
+        throws Exception {
+        FileTransferInformation info = fm.initiateFileTransferFromGuest(vm, creds, guestPath);
+        String hostUrl = UploadFileToGuest.substituteHost(info.getUrl(), vm);
+
+        HttpsConnectionUtil.trustAllHosts();
+        HttpsURLConnection conn = (HttpsURLConnection) new URL(hostUrl).openConnection();
+        conn.setHostnameVerifier(HttpsConnectionUtil.DO_NOT_VERIFY);
+        conn.setRequestMethod("GET");
+
+        int rc = conn.getResponseCode();
+        if (rc < 200 || rc >= 300) {
+            throw new RuntimeException("Download of " + guestPath + " failed: HTTP " + rc);
+        }
+
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
+            byte[] chunk = new byte[8 * 1024];
+            int len;
+            while ((len = in.read(chunk)) != -1) {
+                buf.write(chunk, 0, len);
+            }
+        }
+        conn.disconnect();
+        return buf.toString("UTF-8");
+    }
+}

--- a/src/main/java/com/vmware/vim25/mo/samples/guestos/UploadFileToGuest.java
+++ b/src/main/java/com/vmware/vim25/mo/samples/guestos/UploadFileToGuest.java
@@ -1,0 +1,148 @@
+package com.vmware.vim25.mo.samples.guestos;
+
+import com.vmware.vim25.GuestFileAttributes;
+import com.vmware.vim25.NamePasswordAuthentication;
+import com.vmware.vim25.mo.GuestFileManager;
+import com.vmware.vim25.mo.GuestOperationsManager;
+import com.vmware.vim25.mo.HostSystem;
+import com.vmware.vim25.mo.InventoryNavigator;
+import com.vmware.vim25.mo.ServiceInstance;
+import com.vmware.vim25.mo.VirtualMachine;
+import com.vmware.vim25.mo.samples.HttpsConnectionUtil;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+
+/**
+ * Uploads a local file into a powered-on VM's guest OS using the
+ * GuestFileManager.initiateFileTransferToGuest API.
+ *
+ * <p>Pattern (mirrors what the doublecloud vmguest "putFile" helper did, GitHub issue #49):
+ * <ol>
+ *   <li>Authenticate to vCenter and locate the target VM.</li>
+ *   <li>Authenticate to the guest OS via VMware Tools using NamePasswordAuthentication.</li>
+ *   <li>Call initiateFileTransferToGuest to get a single-use upload URL with a "*" placeholder
+ *       for the host that runs the VM.</li>
+ *   <li>Substitute the actual ESXi host IP/hostname into the URL.</li>
+ *   <li>HTTP PUT the file bytes to that URL.</li>
+ * </ol>
+ *
+ * <p>Requires VMware Tools running in the guest. The guest user must have permission to
+ * write to the destination path.
+ *
+ * <p>Usage:
+ * <pre>
+ * java UploadFileToGuest &lt;url&gt; &lt;vc-user&gt; &lt;vc-pass&gt; &lt;vm-name&gt;
+ *     &lt;guest-user&gt; &lt;guest-pass&gt; &lt;local-file&gt; &lt;guest-path&gt;
+ *
+ * java UploadFileToGuest https://vc01/sdk administrator@vsphere.local vmware123
+ *     test-vm root rootpw /tmp/hello.txt /tmp/hello.txt
+ * </pre>
+ */
+public class UploadFileToGuest {
+
+    private static final int BUFFER_SIZE = 64 * 1024;
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 8) {
+            System.out.println("Usage: java UploadFileToGuest <url> <vc-user> <vc-pass> <vm-name>"
+                + " <guest-user> <guest-pass> <local-file> <guest-path>");
+            System.exit(0);
+        }
+
+        String vcUrl     = args[0];
+        String vcUser    = args[1];
+        String vcPass    = args[2];
+        String vmName    = args[3];
+        String guestUser = args[4];
+        String guestPass = args[5];
+        String localFile = args[6];
+        String guestPath = args[7];
+
+        File local = new File(localFile);
+        if (!local.exists()) {
+            throw new IllegalArgumentException("Local file not found: " + localFile);
+        }
+
+        ServiceInstance si = new ServiceInstance(new URL(vcUrl), vcUser, vcPass, true);
+        try {
+            VirtualMachine vm = (VirtualMachine) new InventoryNavigator(si.getRootFolder())
+                .searchManagedEntity("VirtualMachine", vmName);
+            if (vm == null) {
+                System.out.println("VM not found: " + vmName);
+                return;
+            }
+            if (!"guestToolsRunning".equals(vm.getGuest().toolsRunningStatus)) {
+                System.out.println("VMware Tools not running in guest; cannot proceed.");
+                return;
+            }
+
+            NamePasswordAuthentication creds = new NamePasswordAuthentication();
+            creds.username = guestUser;
+            creds.password = guestPass;
+
+            GuestOperationsManager gom = si.getGuestOperationsManager();
+            GuestFileManager fileManager = gom.getFileManager(vm);
+
+            // Empty GuestFileAttributes lets the guest pick reasonable defaults
+            // (mode/owner on Linux; nothing on Windows). Populate explicitly if
+            // you need specific permissions.
+            GuestFileAttributes attrs = new GuestFileAttributes();
+
+            // initiateFileTransferToGuest returns a URL with a "*" placeholder for the
+            // host running the VM — vCenter expects the caller to substitute it.
+            String uploadUrl = fileManager.initiateFileTransferToGuest(
+                vm, creds, guestPath, attrs, local.length(), /*overwrite=*/true);
+
+            String hostUrl = substituteHost(uploadUrl, vm);
+            System.out.println("Upload URL: " + hostUrl);
+
+            HttpsConnectionUtil.trustAllHosts();
+            URL url = new URL(hostUrl);
+            HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+            conn.setHostnameVerifier(HttpsConnectionUtil.DO_NOT_VERIFY);
+            conn.setDoOutput(true);
+            conn.setRequestMethod("PUT");
+            conn.setRequestProperty("Content-Type", "application/octet-stream");
+            conn.setChunkedStreamingMode(BUFFER_SIZE);
+
+            try (InputStream in = new BufferedInputStream(new FileInputStream(local));
+                 OutputStream out = conn.getOutputStream()) {
+                byte[] buf = new byte[BUFFER_SIZE];
+                int len;
+                while ((len = in.read(buf)) != -1) {
+                    out.write(buf, 0, len);
+                }
+                out.flush();
+            }
+
+            int rc = conn.getResponseCode();
+            System.out.println("HTTP " + rc + " " + conn.getResponseMessage());
+            if (rc < 200 || rc >= 300) {
+                throw new RuntimeException("Upload failed with HTTP " + rc);
+            }
+            System.out.println("Uploaded " + local.length() + " bytes to " + guestPath);
+            conn.disconnect();
+        } finally {
+            si.getServerConnection().logout();
+        }
+    }
+
+    /**
+     * The transfer URL comes back with a "*" placeholder for the ESXi host running the VM.
+     * Replace it with the host's name (vCenter clients can usually reach the host by its
+     * managed name; for environments where they can't, swap in the management IP via
+     * host.getSummary().getConfig() or HostSystem properties).
+     */
+    static String substituteHost(String urlWithStar, VirtualMachine vm) throws Exception {
+        HostSystem host = new HostSystem(
+            vm.getServerConnection(), vm.getRuntime().getHost());
+        String hostName = host.getName();
+        return urlWithStar.replace("*", hostName);
+    }
+}


### PR DESCRIPTION
## Summary

Adds three runnable samples in `src/main/java/com/vmware/vim25/mo/samples/guestos/` that mirror what the doublecloud `vmguest` convenience helpers wrapped — the request in [yavijava#49](https://github.com/yavijava/yavijava/issues/49).

| Sample | What it shows |
|---|---|
| `UploadFileToGuest.java` | `GuestFileManager.initiateFileTransferToGuest` → HTTP PUT, with the \`*\` placeholder substituted from `vm.runtime.host` |
| `DownloadFileFromGuest.java` | `GuestFileManager.initiateFileTransferFromGuest` → HTTP GET, streamed to a local file. Reuses `UploadFileToGuest.substituteHost` so the URL-rewrite detail lives in one place |
| `RunCommandInGuestAndCaptureOutput.java` | The workaround for the Guest Operations API not exposing process stdio: redirect to temp files in the guest, poll `listProcessesInGuest` until exit, download the temp files back, best-effort cleanup |

All three:
- Use `NamePasswordAuthentication` against VMware Tools.
- Reuse `HttpsConnectionUtil.trustAllHosts()` + `DO_NOT_VERIFY` for SSL — matches `DatastoreFileTransfer.java` style.
- Detect the guest family for path/shell selection (`cmd.exe` vs `/bin/sh`) where it matters.

## Test plan

- [x] `./gradlew compileJava` is clean
- [ ] Manual smoke test against a vCenter with a Linux + Windows VM — left for whoever has the lab handy

Closes the spirit of yavijava#49 (will close that issue separately on the main repo with a link to this PR).